### PR TITLE
feat: Add TinyStories BPE training and serialization script

### DIFF
--- a/cs336_basics/train_bpe_tinystories.py
+++ b/cs336_basics/train_bpe_tinystories.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+
+from cs336_basics.train_bpe import train_bpe
+from cs336_basics.bpe import gpt2_bytes_to_unicode
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train a BPE Tokenizer")
+    parser.add_argument("--input_path", type=str, required=True, help="Path to the training data text file")
+    parser.add_argument(
+        "--vocab_output_path", type=str, default="data/tinystories_vocab.json", help="Where to save the vocab JSON"
+    )
+    parser.add_argument(
+        "--merges_output_path",
+        type=str,
+        default="data/tinystories_merges.txt",
+        help="Where to save the merges text file",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Starting BPE training on: {args.input_path}")
+
+    vocab, merges = train_bpe(
+        input_path=args.input_path,
+        vocab_size=10000,
+        special_tokens=["<|endoftext|>"],
+    )
+
+    # Serialize the resulting vocabulary and merges to disk
+    print(f"Training complete! Saving {args.vocab_output_path} and {args.merges_output_path} ...")
+
+    byte_to_unicode = gpt2_bytes_to_unicode()
+    with open(args.vocab_output_path, "w") as f:
+        reversed_vocab = {
+            "".join([byte_to_unicode[token] for token in tokens]): token_id for token_id, tokens in vocab.items()
+        }
+
+        json.dump(reversed_vocab, f, indent=2, ensure_ascii=False)
+
+    with open(args.merges_output_path, "w") as f:
+        for first_token, second_token in merges:
+            first_str = "".join([byte_to_unicode[b] for b in first_token])
+            second_str = "".join([byte_to_unicode[b] for b in second_token])
+            f.write(f"{first_str} {second_str}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR implements the `train_bpe_tinystories.py` executable script. This script orchestrates the training of our custom Byte-Pair Encoding (BPE) tokenizer on the TinyStories dataset and safely serializes the resulting vocabulary and merges into the standard GPT-2 compatible formats.

## Key Implementations & Features

* **Robust CLI Interface (`argparse`)**: 
  * Implemented a flexible command-line interface requiring the user to specify an `--input_path`, allowing seamless swapping between the validation subset and the full training dataset. 
  * Includes sensible, pre-configured defaults for the output paths (`data/tinystories_vocab.json` and `data/tinystories_merges.txt`).
* **Accurate Byte-to-Unicode Serialization**: 
  * Safely converts the internal `dict[int, bytes]` vocabulary into the standard `String -> ID` format required by external systems. Utilizes the `gpt2_bytes_to_unicode()` function to accurately map raw byte integers into printable Unicode strings.
  * Configured the `vocab.json` output with `indent=2` and `ensure_ascii=False` to ensure the generated file is highly readable and correctly formatted.
* **Standardized Merges Output**: 
  * Accurately formats the list of merge tuples into the standard space-separated `merges.txt` format. Applies the proper byte-to-Unicode string mapping simultaneously on both the left and right elements of every merged pair.
* **Execution Logging**: 
  * Added clear status logging (`print` statements) so the user can easily monitor the script's initialization target and completion status.

## How to Run

**To test quickly on the validation set:**
```bash
uv run cs336_basics/train_bpe_tinystories.py --input_path data/TinyStoriesV2-GPT4-valid.txt
