### PR TITLE
feat: Implement custom Linear projection module and adapter

### DIFF
--- a/cs336_basics/linear.py
+++ b/cs336_basics/linear.py
@@ -1,0 +1,25 @@
+import math
+import torch
+import torch.nn as nn
+
+from einops import einsum
+
+
+class Linear(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.device = device
+        self.dtype = dtype
+        self.weight = nn.Parameter(torch.zeros(self.out_features, self.in_features, device=device, dtype=dtype))
+        nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (self.in_features + self.out_features)))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return einsum(x, self.weight, "... d_in, d_out d_in -> ... d_out")

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -11,6 +11,7 @@ from torch import Tensor
 
 from cs336_basics.bpe import BPETokenizer
 from cs336_basics.train_bpe import train_bpe
+from cs336_basics.linear import Linear
 
 
 def run_linear(
@@ -32,7 +33,9 @@ def run_linear(
         Float[Tensor, "... d_out"]: The transformed output of your linear module.
     """
 
-    raise NotImplementedError
+    linear = Linear(d_in, d_out)
+    linear.weight.data = weights
+    return linear(in_features)
 
 
 def run_embedding(


### PR DESCRIPTION
## Description
This PR implements the foundational `Linear` neural network module for the Transformer, built entirely from scratch without relying on PyTorch's built-in `nn.Linear` or `nn.functional.linear`. The implementation strictly adheres to standard PyTorch architectural conventions and the assignment's specific mathematical layout requirements.

## Key Implementations & Features

* **Custom PyTorch Architecture**: 
  * Constructed `Linear` as a formal subclass of `torch.nn.Module`, natively supporting and passing down `device` and `dtype` arguments to ensure immediate GPU compatibility.
  * Added strict Python type hinting to the `__init__` signature to match the exact assignment specification.
* **Mathematical Alignment & Einsum**: 
  * Explicitly constructed the learnable parameter shape as $W \in \mathbb{R}^{d_{out} \times d_{in}}$ `(out_features, in_features)` rather than a transposed matrix.
  * Executed the forward pass using `einops.einsum` with the pattern `"... d_in, d_out d_in -> ... d_out"`. This properly maps the mathematical column-vector equation ($y = Wx$) into the PyTorch row-major execution format ($y = x W^\top$), allowing for stable, n-dimensional batch processing.
* **Custom Initialization**:
  * Initialized the linear weights using truncated normal initialization (`nn.init.trunc_normal_`), scaled appropriately by $\sqrt{2 / (d_{in} + d_{out})}$.
* **Adapter Integration**:
  * Safely hooked the module into `tests/adapters.py::run_linear()`. Handled test-weight injection by overriding `linear.weight.data` to ensure the tensor isn't accidentally decoupled from the module's internal parameter tracker.

## Testing
- ✅ Passed all linear validation tests (`tests/test_model.py::test_linear`).
