### PR TITLE
feat: Implement custom Embedding lookup module

### DIFF
--- a/cs336_basics/embedding.py
+++ b/cs336_basics/embedding.py
@@ -1,0 +1,21 @@
+import math
+import torch
+import torch.nn as nn
+
+
+class Embedding(nn.Module):
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.weight = nn.Parameter(torch.zeros(num_embeddings, embedding_dim, device=device, dtype=dtype))
+        nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (num_embeddings + embedding_dim)))
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.weight[token_ids]

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -12,6 +12,7 @@ from torch import Tensor
 from cs336_basics.bpe import BPETokenizer
 from cs336_basics.train_bpe import train_bpe
 from cs336_basics.linear import Linear
+from cs336_basics.embedding import Embedding
 
 
 def run_linear(
@@ -57,7 +58,9 @@ def run_embedding(
         Float[Tensor, "... d_model"]: Batch of embeddings returned by your Embedding layer.
     """
 
-    raise NotImplementedError
+    embedding = Embedding(vocab_size, d_model)
+    embedding.weight.data = weights
+    return embedding(token_ids)
 
 
 def run_swiglu(


### PR DESCRIPTION
## Description
This PR implements the foundational `Embedding` neural network module. It is built entirely from scratch without relying on PyTorch's built-in `nn.Embedding` module, strictly adhering to standard PyTorch architectural conventions and the assignment's explicit layout requirements.

## Key Implementations & Features

* **Custom PyTorch Architecture**: 
  * Constructed `Embedding` as a formal subclass of `torch.nn.Module`. 
  * Natively supports and passes down `device` and `dtype` arguments during parameter creation to ensure immediate GPU compatibility. Explicitly avoided saving redundant local state (e.g. `self.device`) to prevent "stale state" bugs if the module is dynamically moved across devices during runtime.
  * Added strict Python type hinting to the `__init__` signature to match the exact assignment specification.
* **Efficient Advanced Indexing**: 
  * Explicitly constructed the learnable parameter shape as an un-transposed lookup table `(num_embeddings, embedding_dim)`.
  * Executed the forward pass using PyTorch's native advanced indexing (`self.weight[token_ids]`). This cleanly handles arbitrary batched dimensions of integer indices (e.g., shape `(batch_size, sequence_length)`) and maps them into feature vectors without relying on invalid continuous matrix operations.
* **Custom Initialization**:
  * Initialized the embedding weights using truncated normal initialization (`nn.init.trunc_normal_`), scaled appropriately by $\sqrt{2 / (num\_{embeddings} + embedding\_{dim})}$.

## Testing
- ✅ Passed all embedding validation tests (`tests/test_model.py::test_embedding`).
