### PR TITLE
chore: Refactor and clean up Linear module state

### DIFF
--- a/cs336_basics/linear.py
+++ b/cs336_basics/linear.py
@@ -16,10 +16,8 @@ class Linear(nn.Module):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        self.device = device
-        self.dtype = dtype
-        self.weight = nn.Parameter(torch.zeros(self.out_features, self.in_features, device=device, dtype=dtype))
-        nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (self.in_features + self.out_features)))
+        self.weight = nn.Parameter(torch.zeros(out_features, in_features, device=device, dtype=dtype))
+        nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (in_features + out_features)))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return einsum(x, self.weight, "... d_in, d_out d_in -> ... d_out")


### PR DESCRIPTION
## Description
This PR addresses minor code smells in the `Linear` module to ensure it strictly follows PyTorch best practices regarding device and data-type management.

## Key Changes
* **Removed Stale State Variables**: Removed the redundant `self.device` and `self.dtype` instance variables. This prevents potential "stale state" bugs where the module could be dynamically moved to a new device (e.g., via `.to("cuda")`) while `self.device` incorrectly still holds the value `None` or `"cpu"`.
* **Cleaned Parameter Initialization**: Refactored the `torch.zeros` and `trunc_normal_` initialization calls to directly use the cleanly passed `device`, `dtype`, `in_features`, and `out_features` local variables. This avoids unnecessary `self` lookups and improves overall code terseness.

## Testing
- ✅ The linear validation suite (`tests/test_model.py::test_linear`) continues to pass successfully.
