### PR TITLE
fix: Align embedding initialization with PyTorch defaults

### DIFF
--- a/cs336_basics/embedding.py
+++ b/cs336_basics/embedding.py
@@ -1,4 +1,3 @@
-import math
 import torch
 import torch.nn as nn
 
@@ -15,7 +14,7 @@ class Embedding(nn.Module):
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
         self.weight = nn.Parameter(torch.zeros(num_embeddings, embedding_dim, device=device, dtype=dtype))
-        nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (num_embeddings + embedding_dim)))
+        nn.init.trunc_normal_(self.weight, mean=0.0, std=1)
 
     def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.weight[token_ids]


### PR DESCRIPTION
## Description
This PR corrects the weight initialization logic for the custom `Embedding` module to properly mirror standard PyTorch behavior.

## Key Changes
* **Removed Linear Scaling**: Previously, the embedding weights incorrectly applied a Xavier/He-style variance scaling formula (`math.sqrt(2 / (num_embeddings + embedding_dim))`). Because embedding tables perform discrete index lookups rather than continuous matrix multiplications, variance scaling is unnecessary and incorrect.
* **Aligned with PyTorch Defaults**: Updated the initialization standard deviation to `1`. This directly mirrors the default behavior of PyTorch's native `nn.Embedding` module, which initializes parameters using a standard normal distribution ($\mathcal{N}(0, 1)$). 
