### PR TITLE
feat: Implement RMSNorm module with mixed-precision safety

### DIFF
--- a/cs336_basics/rmsnorm.py
+++ b/cs336_basics/rmsnorm.py
@@ -1,0 +1,25 @@
+import torch
+import torch.nn as nn
+
+
+class RMSNorm(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        eps: float = 1e-5,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model, device=device, dtype=dtype))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_type = x.dtype
+        x = x.to(torch.float)
+        square_mean = torch.mean(x**2, dim=-1, keepdim=True)
+        rms = torch.sqrt(square_mean + self.eps)
+        x_normed = x / rms
+        result = x_normed * self.weight
+        return result.to(in_type)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -13,6 +13,7 @@ from cs336_basics.bpe import BPETokenizer
 from cs336_basics.train_bpe import train_bpe
 from cs336_basics.linear import Linear
 from cs336_basics.embedding import Embedding
+from cs336_basics.rmsnorm import RMSNorm
 
 
 def run_linear(
@@ -387,7 +388,10 @@ def run_rmsnorm(
         Float[Tensor,"... d_model"]: Tensor of with the same shape as `in_features` with the output of running
         RMSNorm of the `in_features`.
     """
-    raise NotImplementedError
+
+    rms_norm = RMSNorm(d_model, eps)
+    rms_norm.weight.data = weights
+    return rms_norm(in_features)
 
 
 def run_silu(in_features: Float[Tensor, " ..."]) -> Float[Tensor, " ..."]:


### PR DESCRIPTION
## Description
This PR introduces the `RMSNorm` (Root Mean Square Normalization) layer, built entirely from scratch following rigorous PyTorch structural best practices. 

## Key Implementations & Features
* **Custom Architecture**: 
  * Subclassed `torch.nn.Module` and correctly initialized the learnable scaling vector (`self.weight`) as an `nn.Parameter` of shape `(d_model,)`, initialized to 1.
  * Included complete Python type hinting for the constructor (`device`, `dtype`, `eps`, etc.) matching the assignment specifications.
* **Mathematical Accuracy & Broadcasting**:
  * Correctly calculated the mean of squares across the feature dimension using `dim=-1` and `keepdim=True`. This critical use of `keepdim` preserves the `(batch, seq, 1)` shape, enabling PyTorch to seamlessly broadcast the subsequent `x / rms` normalization step without dimension mismatch errors.
* **Mixed-Precision Safety (Upcasting)**:
  * Implemented a critical numerical stability technique used in large-scale LLM training: explicitly upcasting the input `x` to `torch.float32` before computing the variance. This securely prevents exponentiation overflow/underflow when operating in `bfloat16` or `float16` environments, safely downcasting back to the original `in_type` at the end of the forward pass.

## Testing
- ✅ Successfully passes all RMSNorm validation tests (`tests/test_model.py::test_rmsnorm`).
