### PR TITLE
feat: Implement SwiGLU position-wise feed-forward network

### DIFF
--- a/cs336_basics/positionwise_feedforward.py
+++ b/cs336_basics/positionwise_feedforward.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn as nn
+
+from cs336_basics.linear import Linear
+
+
+class SwiGLU(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        d_ff: int,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_ff = d_ff
+        self.w1 = Linear(d_model, d_ff)
+        self.w2 = Linear(d_ff, d_model)
+        self.w3 = Linear(d_model, d_ff)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        w1_out = self.w1(x)
+        w3_out = self.w3(x)
+
+        hidden = w1_out * torch.sigmoid(w1_out) * w3_out
+
+        return self.w2(hidden)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -14,6 +14,7 @@ from cs336_basics.train_bpe import train_bpe
 from cs336_basics.linear import Linear
 from cs336_basics.embedding import Embedding
 from cs336_basics.rmsnorm import RMSNorm
+from cs336_basics.positionwise_feedforward import SwiGLU
 
 
 def run_linear(
@@ -93,7 +94,13 @@ def run_swiglu(
     # swiglu.w1.weight.data = w1_weight
     # swiglu.w2.weight.data = w2_weight
     # swiglu.w3.weight.data = w3_weight
-    raise NotImplementedError
+
+    swiglu = SwiGLU(d_model, d_ff)
+    swiglu.w1.weight.data = w1_weight
+    swiglu.w2.weight.data = w2_weight
+    swiglu.w3.weight.data = w3_weight
+
+    return swiglu(in_features)
 
 
 def run_scaled_dot_product_attention(


### PR DESCRIPTION
## Description
This PR introduces the `SwiGLU` position-wise feed-forward module for the Transformer architecture, replacing the traditional ReLU-based FFN with the modern, gated variant used in architectures like Llama 3 and Qwen 2.5. 

## Key Implementations & Features
* **Custom Architecture Assembly**: 
  * Assembled the layer from scratch using the custom `Linear` projections implemented earlier in the assignment, successfully avoiding reliance on PyTorch's native `nn.Linear` or `nn.Transformer` classes.
* **Rigorous Dimensional Routing**:
  * $W_1$ and $W_3$ are correctly instantiated as `Linear(d_model, d_ff)` to capture the initial `d_model` input sequence and project it into the wider intermediate `d_ff` hidden space.
  * $W_2$ correctly serves as the down-projection layer `Linear(d_ff, d_model)` to route the gated outputs back to the original sequence dimension. 
* **Numerical Stability in Activation**:
  * Handled the Swish/SiLU activation function manually via $x \cdot \sigma(x)$. Strictly adhered to the assignment hints by utilizing `torch.sigmoid` to handle the logistic scaling. This correctly leverages the PyTorch backend's built-in C++ safeguards against severe exponential overflow/underflow, rather than unsafely calculating $(1 + \exp(-x))^{-1}$ from scratch.
* **Gated Linear Unit ($\odot$)**:
  * Accurately combined the independent $W_1$ (activated) and $W_3$ projections using element-wise gated multiplication (`*`) before the final $W_2$ down-projection.

## Testing
- ✅ Passed `tests/test_model.py::test_swiglu`
