### PR TITLE
fix: Propagate device and dtype arguments in SwiGLU submodules

### DIFF
--- a/cs336_basics/positionwise_feedforward.py
+++ b/cs336_basics/positionwise_feedforward.py
@@ -15,9 +15,9 @@ class SwiGLU(nn.Module):
         super().__init__()
         self.d_model = d_model
         self.d_ff = d_ff
-        self.w1 = Linear(d_model, d_ff)
-        self.w2 = Linear(d_ff, d_model)
-        self.w3 = Linear(d_model, d_ff)
+        self.w1 = Linear(d_model, d_ff, device, dtype)
+        self.w2 = Linear(d_ff, d_model, device, dtype)
+        self.w3 = Linear(d_model, d_ff, device, dtype)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         w1_out = self.w1(x)


### PR DESCRIPTION
## Description
This PR addresses a critical state-propagation bug in the `SwiGLU` module initialization. Previously, the `device` and `dtype` arguments provided to the `SwiGLU` constructor were effectively ignored, as they were not passed down to the underlying custom `Linear` layers.

## Key Changes
* **Device & Precision Propagation**: Explicitly passed the `device` and `dtype` variables into the constructors for the $W_1$, $W_2$, and $W_3$ `Linear` projections.
* **GPU Memory Safety**: This ensures that when the parent `SwiGLU` module is instantiated for mixed-precision (e.g., `bfloat16`) or directly onto an accelerator (`device='cuda'`), its massive internal weight tensors are immediately allocated correctly, preventing CPU-RAM OOMs and unexpected device mismatches during the forward pass.
