### PR TITLE
docs: Add comprehensive PyTorch-standard docstrings to core modules

### DIFF
--- a/cs336_basics/embedding.py
+++ b/cs336_basics/embedding.py
@@ -3,6 +3,13 @@ import torch.nn as nn
 
 
 class Embedding(nn.Module):
+    """
+    A simple lookup table that stores embeddings of a fixed dictionary and size.
+
+    This module retrieves dense continuous vectors given discrete integer token IDs,
+    acting as the first layer mapping tokens into the model's hidden dimension.
+    """
+
     def __init__(
         self,
         num_embeddings: int,
@@ -17,4 +24,13 @@ class Embedding(nn.Module):
         nn.init.trunc_normal_(self.weight, mean=0.0, std=1)
 
     def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """
+        Retrieves the embedding vectors for a batch of token IDs.
+        Args:
+            token_ids (torch.Tensor): A tensor of integer token IDs of shape (...,).
+                                      Often shape (batch_size, sequence_length).
+
+        Returns:
+            torch.Tensor: The mapped dense embeddings of shape (..., embedding_dim).
+        """
         return self.weight[token_ids]

--- a/cs336_basics/linear.py
+++ b/cs336_basics/linear.py
@@ -6,6 +6,13 @@ from einops import einsum
 
 
 class Linear(nn.Module):
+    """
+    Applies a linear transformation to the incoming data: y = xA^T.
+
+    This module performs a learnable matrix multiplication without a bias term,
+    matching modern LLM architectural standards.
+    """
+
     def __init__(
         self,
         in_features: int,
@@ -20,4 +27,12 @@ class Linear(nn.Module):
         nn.init.trunc_normal_(self.weight, mean=0.0, std=math.sqrt(2 / (in_features + out_features)))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculates the forward pass of the linear projection.
+        Args:
+            x (torch.Tensor): The input tensor of shape (..., in_features).
+
+        Returns:
+            torch.Tensor: The projected output tensor of shape (..., out_features).
+        """
         return einsum(x, self.weight, "... d_in, d_out d_in -> ... d_out")

--- a/cs336_basics/positionwise_feedforward.py
+++ b/cs336_basics/positionwise_feedforward.py
@@ -6,6 +6,15 @@ from cs336_basics.linear import Linear
 
 
 class SwiGLU(nn.Module):
+    """
+    A position-wise feed-forward network utilizing the SwiGLU activation mechanism.
+
+    Combines a Swish (SiLU) activation function with a Gated Linear Unit (GLU).
+    The input is projected independently via two linear layers; one pathway is
+    activated and acts as a multiplicative gate to the other, before a final
+    linear down-projection.
+    """
+
     def __init__(
         self,
         d_model: int,
@@ -21,6 +30,14 @@ class SwiGLU(nn.Module):
         self.w3 = Linear(d_model, d_ff, device, dtype)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculates the SwiGLU forward pass over the sequence.
+        Args:
+            x (torch.Tensor): The input hidden states of shape (..., d_model).
+
+        Returns:
+            torch.Tensor: The output hidden states of shape (..., d_model).
+        """
         w1_out = self.w1(x)
         w3_out = self.w3(x)
 

--- a/cs336_basics/rmsnorm.py
+++ b/cs336_basics/rmsnorm.py
@@ -3,6 +3,14 @@ import torch.nn as nn
 
 
 class RMSNorm(nn.Module):
+    """
+    Root Mean Square Layer Normalization (RMSNorm).
+
+    A mathematically simplified and computationally cheaper alternative to LayerNorm
+    that normalizes activations strictly by their root mean square, ignoring mean centering.
+    Widely used in modern architectures like LLaMA.
+    """
+
     def __init__(
         self,
         d_model: int,
@@ -16,6 +24,17 @@ class RMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(d_model, device=device, dtype=dtype))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Applies RMS normalization to the input tensor.
+        Calculations are internally upcasted to float32 for numerical stability
+        before being scaled by the learnable weight parameter.
+        Args:
+            x (torch.Tensor): The input tensor of shape (..., d_model).
+
+        Returns:
+            torch.Tensor: The normalized tensor of shape (..., d_model), returned
+                          in the original input data type.
+        """
         in_type = x.dtype
         x = x.to(torch.float)
         square_mean = torch.mean(x**2, dim=-1, keepdim=True)


### PR DESCRIPTION
## Description
This PR significantly elevates the codebase's quality and maintainability by introducing comprehensive, PyTorch-standard docstrings to all core Transformer modules (`Linear`, `Embedding`, `RMSNorm`, and `SwiGLU`).

## Key Additions
* **Class-level Documentation**: Added high-level mathematical and architectural descriptions for each module, explaining their role within the broader LLM architecture.
* **Shape Mapping (`forward` passes)**: Exhaustively documented the `forward` methods, strictly defining the expected input tensor shapes (e.g., `(..., d_model)`) and the resulting output tensor shapes. This resolves ambiguity and heavily streamlines future debugging and architectural expansion.
