### PR TITLE
feat: Implement Rotary Positional Embedding (RoPE)

### DIFF
--- a/cs336_basics/rope.py
+++ b/cs336_basics/rope.py
@@ -1,0 +1,53 @@
+import torch
+import torch.nn as nn
+
+
+class RotaryPositionalEmbedding(nn.Module):
+    """
+    Rotary Positional Embedding (RoPE).
+    Encodes positional information directly into the queries and keys by rotating
+    their representations in the complex plane. RoPE applies a relative positional
+    encoding using precomputed trigonometric frequencies, allowing the model to
+    better generalize to sequence lengths beyond the training distribution.
+    """
+
+    def __init__(self, d_k: int, theta: float, max_seq_len: int, device: torch.device | str | None = None):
+        super().__init__()
+        self.d_k = d_k
+        self.theta = theta
+        self.max_seq_len = max_seq_len
+
+        k = torch.arange(0, d_k // 2, device=device)
+        angles = 1 / theta ** (2 * k / d_k)
+        positions = torch.arange(max_seq_len, device=device)
+        rotations = torch.outer(positions, angles)
+
+        cos_tensor = torch.cos(rotations)
+        sin_tensor = torch.sin(rotations)
+
+        self.register_buffer("cos_cached", cos_tensor)
+        self.register_buffer("sin_cached", sin_tensor)
+
+    def forward(self, x: torch.Tensor, token_positions: torch.Tensor) -> torch.Tensor:
+        """
+        Applies rotary positional embeddings to the input tensor.
+        Extracts the precomputed cosine and sine frequencies corresponding to the
+        provided token positions, and applies a 2D rotation matrix to interleaved
+        pairs of feature dimensions.
+        Args:
+            x (torch.Tensor): The input tensor (queries or keys) to be rotated.
+                              Typically of shape (..., seq_len, d_k).
+            token_positions (torch.Tensor): Integer tensor of sequence positions
+                                            corresponding to the inputs.
+                                            Shape must broadcast against x.
+        Returns:
+            torch.Tensor: The rotated tensor of the exact same shape as the input `x`.
+        """
+        cos = self.cos_cached[token_positions]
+        sin = self.sin_cached[token_positions]
+
+        x1, x2 = x[..., 0::2], x[..., 1::2]
+        y1 = x1 * cos - x2 * sin
+        y2 = x1 * sin + x2 * cos
+
+        return torch.stack([y1, y2], dim=-1).flatten(-2)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -15,6 +15,7 @@ from cs336_basics.linear import Linear
 from cs336_basics.embedding import Embedding
 from cs336_basics.rmsnorm import RMSNorm
 from cs336_basics.positionwise_feedforward import SwiGLU
+from cs336_basics.rope import RotaryPositionalEmbedding
 
 
 def run_linear(
@@ -217,7 +218,9 @@ def run_rope(
     Returns:
         Float[Tensor, " ... sequence_length d_k"]: Tensor with RoPEd input.
     """
-    raise NotImplementedError
+
+    rope = RotaryPositionalEmbedding(d_k, theta, max_seq_len)
+    return rope(in_query_or_key, token_positions)
 
 
 def run_transformer_block(


### PR DESCRIPTION
## Description
This PR introduces the `RotaryPositionalEmbedding` (RoPE) module, the modern standard for injecting relative sequence position information directly into the Query and Key projection matrices.

## Key Implementations & Features
* **Efficient Precomputation**: 
  * Avoids dense rotation matrix multiplication. Instead, calculates the base frequency parameters ($\theta^{-2i/d}$) exactly once during initialization.
  * Expands these parameters across the maximum sequence length using a computationally cheap outer product (`torch.outer`).
* **State Management**:
  * Utilizes `register_buffer` to permanently cache the resulting `cos` and `sin` trigonometric matrices. This ensures they correctly migrate when calling `.to('cuda')` but are hidden from the `AdamW` optimizer's gradient updates.
* **Vectorized Rotation Application**:
  * The `forward` pass dynamically slices the precomputed buffers based on the input `token_positions`, handling both standard sequence layouts and dynamic batching smoothly.
  * Applies the 2D affine rotation mathematically to interleaved `(even, odd)` feature dimensions, avoiding expensive block-diagonal matrix operations.
* **Documentation**: 
  * Fully documented with PyTorch-standard docstrings defining inputs, outputs, and tensor shapes.

## Testing
- ✅ Passed `tests/test_model.py::test_rope`
