### PR TITLE
feat: Implement Numerically Stable Softmax

### DIFF
--- a/cs336_basics/softmax.py
+++ b/cs336_basics/softmax.py
@@ -1,0 +1,8 @@
+import torch
+
+
+def softmax(x: torch.Tensor, dim: int) -> torch.Tensor:
+    x_max = torch.amax(x, dim, keepdim=True)
+    x_shifted = x - x_max
+    x_exp = torch.exp(x_shifted)
+    return x_exp / torch.sum(x_exp, dim, keepdim=True)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -16,6 +16,7 @@ from cs336_basics.embedding import Embedding
 from cs336_basics.rmsnorm import RMSNorm
 from cs336_basics.positionwise_feedforward import SwiGLU
 from cs336_basics.rope import RotaryPositionalEmbedding
+from cs336_basics.softmax import softmax
 
 
 def run_linear(
@@ -454,7 +455,8 @@ def run_softmax(in_features: Float[Tensor, " ..."], dim: int) -> Float[Tensor, "
         Float[Tensor, "..."]: Tensor of with the same shape as `in_features` with the output of
         softmax normalizing the specified `dim`.
     """
-    raise NotImplementedError
+
+    return softmax(in_features, dim)
 
 
 def run_cross_entropy(


### PR DESCRIPTION
## Description
This PR introduces a custom, mathematically exact, and numerically stable implementation of the Softmax operation from scratch.

## Key Implementations & Features
* **Numerical Stability**:
  * Employs the "max trick" by computing `x_max = torch.amax(x)` and shifting the input values before exponentiation (`x - x_max`). This guarantees all exponential inputs are $\le 0$, effectively preventing mathematical overflows (`inf` or `NaN`) when processing extremely large logits during training.
* **Dynamic Dimensional Broadcasting**:
  * Enforces `keepdim=True` during both `amax` and `sum` reductions. This elegantly maintains the tensor topology, allowing the division ratio to broadcast seamlessly across arbitrary batch, head, and sequence dimensions.
* **Modular Integration**:
  * Hooked into `tests/adapters.py` via `run_softmax` to replace the `NotImplementedError` and expose the utility to the testing suite.

## Testing
- ✅ Passed `tests/test_nn_utils.py::test_softmax_matches_pytorch` against PyTorch's native `F.softmax`.
