### PR TITLE
feat: Implement Scaled Dot-Product Attention

### DIFF
--- a/cs336_basics/scaled_dot_product_attention.py
+++ b/cs336_basics/scaled_dot_product_attention.py
@@ -1,0 +1,29 @@
+import math
+import torch
+
+from einops import einsum
+from cs336_basics.softmax import softmax
+
+
+def scaled_dot_product_attention(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: torch.Tensor | None = None
+) -> torch.Tensor:
+    """
+    Computes scaled dot-product attention.
+    Args:
+        q: Query tensor of shape (..., seq_q, d_k)
+        k: Key tensor of shape (..., seq_k, d_k)
+        v: Value tensor of shape (..., seq_k, d_v)
+        mask: Optional boolean mask tensor of shape (..., seq_q, seq_k).
+              True indicates values to keep, False indicates values to mask.
+    Returns:
+        The output tensor of shape (..., seq_q, d_v).
+    """
+    d_k = q.size(-1)
+    scores = einsum(q, k, "... seq_q d_k, ... seq_k d_k -> ... seq_q seq_k")
+
+    if mask is not None:
+        scores.masked_fill_(~mask, float("-inf"))
+
+    attn_probs = softmax(scores / math.sqrt(d_k), -1)
+    return einsum(attn_probs, v, "... seq_q seq_k, ... seq_k d_v -> ... seq_q d_v")

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -17,6 +17,7 @@ from cs336_basics.rmsnorm import RMSNorm
 from cs336_basics.positionwise_feedforward import SwiGLU
 from cs336_basics.rope import RotaryPositionalEmbedding
 from cs336_basics.softmax import softmax
+from cs336_basics.scaled_dot_product_attention import scaled_dot_product_attention
 
 
 def run_linear(
@@ -123,7 +124,8 @@ def run_scaled_dot_product_attention(
     Returns:
         Float[Tensor, " ... queries d_v"]: Output of SDPA
     """
-    raise NotImplementedError
+
+    return scaled_dot_product_attention(Q, K, V, mask)
 
 
 def run_multihead_self_attention(


### PR DESCRIPTION
## Description
This PR implements the Scaled Dot-Product Attention mechanism as a pure functional utility, passing all associated tests.

## Key Implementations & Features
* **Einsum for Readability and Broadcasting**: 
  * Replaced manual transposition and matrix multiplication operations with explicit `einsum` patterns. This natively handles arbitrary batch shapes (`...`) and improves code readability.
* **Numerical Scaling**: 
  * Accurately scales the dot products by $\frac{1}{\sqrt{d_k}}$ to prevent gradient vanishing issues during softmax.
* **Optional Masking Support**: 
  * Safely handles attention masks by filling masked-out positions with negative infinity before applying softmax.
* **Standard Documentation**:
  * Includes descriptive docstrings with tensor shape expectations and full type hinting.

## Testing
- ✅ Passed `tests/test_model.py::test_scaled_dot_product_attention`
