### PR TITLE
feat: Implement Multi-Head Self-Attention with RoPE support

### DIFF
--- a/cs336_basics/multihead_self_attention.py
+++ b/cs336_basics/multihead_self_attention.py
@@ -23,7 +23,7 @@ class MultiheadSelfAttention(nn.Module):
         d_model: int,
         num_heads: int,
         theta: float | None = None,
-        max_seq_len: float | None = None,
+        max_seq_len: int | None = None,
         device: torch.device | str | None = None,
         dtype: torch.dtype | None = None,
     ):
@@ -68,7 +68,7 @@ class MultiheadSelfAttention(nn.Module):
             v_proj, "... seq_len (num_heads head_dim) -> ... num_heads seq_len head_dim", num_heads=self.num_heads
         )
 
-        if self.rope:
+        if self.rope and token_positions is not None:
             q_proj = self.rope(q_proj, token_positions)
             k_proj = self.rope(k_proj, token_positions)
 

--- a/cs336_basics/multihead_self_attention.py
+++ b/cs336_basics/multihead_self_attention.py
@@ -1,0 +1,80 @@
+import torch
+import torch.nn as nn
+
+from einops import rearrange
+
+from cs336_basics.linear import Linear
+from cs336_basics.rope import RotaryPositionalEmbedding
+from cs336_basics.scaled_dot_product_attention import scaled_dot_product_attention
+
+
+class MultiheadSelfAttention(nn.Module):
+    """
+    Applies multi-head self-attention to the incoming data.
+
+    This module performs linear projections for queries, keys, and values,
+    splits them into multiple heads, applies scaled dot-product attention
+    with a causal mask, and projects the concatenated outputs back to the
+    original model dimension.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        num_heads: int,
+        theta: float | None = None,
+        max_seq_len: float | None = None,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+
+        assert d_model % num_heads == 0
+
+        self.d_model = d_model
+        self.num_heads = num_heads
+        if theta and max_seq_len:
+            self.rope = RotaryPositionalEmbedding(d_model // num_heads, theta, max_seq_len, device=device)
+        else:
+            self.rope = None
+        self.q_proj = Linear(d_model, d_model, device=device, dtype=dtype)
+        self.k_proj = Linear(d_model, d_model, device=device, dtype=dtype)
+        self.v_proj = Linear(d_model, d_model, device=device, dtype=dtype)
+        self.o_proj = Linear(d_model, d_model, device=device, dtype=dtype)
+
+    def forward(self, x: torch.Tensor, token_positions: torch.Tensor | None = None) -> torch.Tensor:
+        """
+        Calculates the forward pass of the multi-head self-attention.
+
+        Args:
+            x (torch.Tensor): The input tensor of shape (..., seq_len, d_model).
+
+        Returns:
+            torch.Tensor: The output tensor of shape (..., seq_len, d_model)
+                         after applying multi-head self-attention.
+        """
+
+        q_proj = self.q_proj(x)
+        k_proj = self.k_proj(x)
+        v_proj = self.v_proj(x)
+
+        q_proj = rearrange(
+            q_proj, "... seq_len (num_heads head_dim) -> ... num_heads seq_len head_dim", num_heads=self.num_heads
+        )
+        k_proj = rearrange(
+            k_proj, "... seq_len (num_heads head_dim) -> ... num_heads seq_len head_dim", num_heads=self.num_heads
+        )
+        v_proj = rearrange(
+            v_proj, "... seq_len (num_heads head_dim) -> ... num_heads seq_len head_dim", num_heads=self.num_heads
+        )
+
+        if self.rope:
+            q_proj = self.rope(q_proj, token_positions)
+            k_proj = self.rope(k_proj, token_positions)
+
+        seq_len = x.size(-2)
+        mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool, device=x.device))
+
+        attention = scaled_dot_product_attention(q_proj, k_proj, v_proj, mask=mask)
+        attention = rearrange(attention, "... num_heads seq_len head_dim -> ... seq_len (num_heads head_dim)")
+        return self.o_proj(attention)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -18,6 +18,7 @@ from cs336_basics.positionwise_feedforward import SwiGLU
 from cs336_basics.rope import RotaryPositionalEmbedding
 from cs336_basics.softmax import softmax
 from cs336_basics.scaled_dot_product_attention import scaled_dot_product_attention
+from cs336_basics.multihead_self_attention import MultiheadSelfAttention
 
 
 def run_linear(
@@ -159,7 +160,14 @@ def run_multihead_self_attention(
         Float[Tensor, " ... sequence_length d_model"]: Tensor with the output of running your optimized, batched multi-headed attention
         implementation with the given QKV projection weights and input features.
     """
-    raise NotImplementedError
+
+    multihead_self_attention = MultiheadSelfAttention(d_model, num_heads)
+    multihead_self_attention.q_proj.weight.data = q_proj_weight
+    multihead_self_attention.k_proj.weight.data = k_proj_weight
+    multihead_self_attention.v_proj.weight.data = v_proj_weight
+    multihead_self_attention.o_proj.weight.data = o_proj_weight
+
+    return multihead_self_attention(in_features)
 
 
 def run_multihead_self_attention_with_rope(
@@ -199,7 +207,13 @@ def run_multihead_self_attention_with_rope(
         Float[Tensor, " ... sequence_length d_model"]: Tensor with the output of running your optimized, batched multi-headed attention
         implementation with the given QKV projection weights and input features.
     """
-    raise NotImplementedError
+    multihead_self_attention = MultiheadSelfAttention(d_model, num_heads, theta=theta, max_seq_len=max_seq_len)
+    multihead_self_attention.q_proj.weight.data = q_proj_weight
+    multihead_self_attention.k_proj.weight.data = k_proj_weight
+    multihead_self_attention.v_proj.weight.data = v_proj_weight
+    multihead_self_attention.o_proj.weight.data = o_proj_weight
+
+    return multihead_self_attention(in_features, token_positions=token_positions)
 
 
 def run_rope(


### PR DESCRIPTION
## Description
This PR completes the implementation of the `MultiheadSelfAttention` module, adding support for both standard multi-head attention and Rotary Positional Embeddings (RoPE).

## Key Implementations & Features
* **Dual Support**: Can be used as standard Multi-Head Attention or with RoPE by passing `theta` and `max_seq_len` to the constructor.
* **RoPE Integration**: Applies RoPE to query and key projections *after* splitting into heads (operating on the head dimension `d_model // num_heads`), ensuring correctness according to standard LLM implementations.
* **Causal Masking**: Generates an internal causal mask to ensure tokens can only attend to past and present tokens (Decoder-only style).
* **Einops Excellence**: Uses `einops.rearrange` for clear and bug-free splitting and merging of heads.

## Testing
* `test_multihead_self_attention` PASSED.
* Ready to verify `test_multihead_self_attention_with_rope`.
