### PR TITLE
feat: Implement Pre-LN Transformer Block with automatic position generation

### DIFF
--- a/cs336_basics/transformer_block.py
+++ b/cs336_basics/transformer_block.py
@@ -1,0 +1,50 @@
+import torch
+import torch.nn as nn
+
+from cs336_basics.rmsnorm import RMSNorm
+from cs336_basics.positionwise_feedforward import SwiGLU
+from cs336_basics.multihead_self_attention import MultiheadSelfAttention
+
+
+class TransformerBlock(nn.Module):
+    """
+    A single layer of a Transformer model using the Pre-LN architecture.
+
+    This module combines Multi-Head Self-Attention and a Position-Wise
+    Feed-Forward network (SwiGLU). It applies RMSNorm before each
+    sub-layer and includes residual connections after each sub-layer.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        num_heads: int,
+        d_ff: int,
+        max_seq_len: int,
+        theta: float,
+        device: torch.device | str | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        super().__init__()
+        self.ln1 = RMSNorm(d_model, device=device, dtype=dtype)
+        self.ffn = SwiGLU(d_model, d_ff, device=device, dtype=dtype)
+        self.ln2 = RMSNorm(d_model, device=device, dtype=dtype)
+        self.attn = MultiheadSelfAttention(
+            d_model, num_heads, theta=theta, max_seq_len=max_seq_len, device=device, dtype=dtype
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Calculates the forward pass of the Transformer block.
+
+        Args:
+            x (torch.Tensor): The input hidden states of shape (..., seq_len, d_model).
+
+        Returns:
+            torch.Tensor: The output hidden states of shape (..., seq_len, d_model)
+                         after applying attention and feed-forward operations.
+        """
+
+        token_positions = torch.arange(x.size(-2), device=x.device)
+        y = x + self.attn(self.ln1(x), token_positions=token_positions)
+        return y + self.ffn(self.ln2(y))

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -19,6 +19,7 @@ from cs336_basics.rope import RotaryPositionalEmbedding
 from cs336_basics.softmax import softmax
 from cs336_basics.scaled_dot_product_attention import scaled_dot_product_attention
 from cs336_basics.multihead_self_attention import MultiheadSelfAttention
+from cs336_basics.transformer_block import TransformerBlock
 
 
 def run_linear(
@@ -310,7 +311,18 @@ def run_transformer_block(
         Float[Tensor, "batch sequence_length d_model"] Tensor with the output of
         running the Transformer block on the input features while using RoPE.
     """
-    raise NotImplementedError
+
+    transformer_block = TransformerBlock(d_model, num_heads, d_ff, max_seq_len, theta)
+    transformer_block.attn.q_proj.weight.data = weights["attn.q_proj.weight"]
+    transformer_block.attn.k_proj.weight.data = weights["attn.k_proj.weight"]
+    transformer_block.attn.v_proj.weight.data = weights["attn.v_proj.weight"]
+    transformer_block.attn.o_proj.weight.data = weights["attn.output_proj.weight"]
+    transformer_block.ln1.weight.data = weights["ln1.weight"]
+    transformer_block.ffn.w1.weight.data = weights["ffn.w1.weight"]
+    transformer_block.ffn.w2.weight.data = weights["ffn.w2.weight"]
+    transformer_block.ffn.w3.weight.data = weights["ffn.w3.weight"]
+    transformer_block.ln2.weight.data = weights["ln2.weight"]
+    return transformer_block(in_features)
 
 
 def run_transformer_lm(


### PR DESCRIPTION
## Description
This PR implements the `TransformerBlock` module, representing a single layer of the Transformer architecture. It integrates the previously built custom modules (`RMSNorm`, `SwiGLU`, and `MultiheadSelfAttention`) using the modern Pre-LN configuration.

## Key Implementations & Features
* **Pre-LN Architecture**: Applies layer normalization (RMSNorm) *before* the self-attention and feed-forward operations, and adds residual connections afterward.
* **Automatic Position Generation**: Automatically infers the sequence length from the input tensor and generates `token_positions` for RoPE on the fly, making the block easier to use without passing positions manually.
* **Feature Integration**: Successfully wires together SwiGLU, Multi-Head Attention with RoPE, and RMSNorm.

## Testing
* `test_transformer_block` PASSED.
* All components verified to handle dimensions correctly.
