### PR TITLE
feat: Implement Cosine Learning Rate Schedule with Warmup

### DIFF
--- a/cs336_basics/learning_rate_schedule.py
+++ b/cs336_basics/learning_rate_schedule.py
@@ -1,0 +1,43 @@
+import math
+
+
+def get_lr_cosine_schedule(
+    it: int,
+    max_learning_rate: float,
+    min_learning_rate: float,
+    warmup_iters: int,
+    cosine_cycle_iters: int,
+) -> float:
+    """
+    Computes the learning rate at a given iteration under a cosine decay schedule with linear warmup.
+
+    The schedule increases the learning rate linearly from 0 to max_learning_rate during
+    the warmup iterations, then decays it to min_learning_rate following a cosine curve up
+    to cosine_cycle_iters. For any iterations after cosine_cycle_iters, the learning rate
+    remains constant at min_learning_rate.
+
+    Args:
+        it (int): The current iteration number.
+        max_learning_rate (float): The maximum learning rate at the peak of warmup.
+        min_learning_rate (float): The minimum/final learning rate after cosine decay.
+        warmup_iters (int): The number of warmup iterations.
+        cosine_cycle_iters (int): The total number of iterations for the warmup + decay cycle.
+
+    Returns:
+        float: The learning rate at iteration `it`.
+    """
+
+    assert warmup_iters < cosine_cycle_iters
+
+    if it < warmup_iters:
+        return it * max_learning_rate / warmup_iters
+
+    if it <= cosine_cycle_iters:
+        return (
+            min_learning_rate
+            + (1 + math.cos((it - warmup_iters) * math.pi / (cosine_cycle_iters - warmup_iters)))
+            * (max_learning_rate - min_learning_rate)
+            / 2
+        )
+
+    return min_learning_rate

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -23,6 +23,7 @@ from cs336_basics.transformer_block import TransformerBlock
 from cs336_basics.transformer_lm import TransformerLM
 from cs336_basics.cross_entropy import cross_entropy
 from cs336_basics.adamw import AdamW
+from cs336_basics.learning_rate_schedule import get_lr_cosine_schedule
 
 
 def run_linear(
@@ -568,7 +569,8 @@ def run_get_lr_cosine_schedule(
     Returns:
         Learning rate at the given iteration under the specified schedule.
     """
-    raise NotImplementedError
+
+    return get_lr_cosine_schedule(it, max_learning_rate, min_learning_rate, warmup_iters, cosine_cycle_iters)
 
 
 def run_save_checkpoint(


### PR DESCRIPTION
## Description
This PR implements the `get_lr_cosine_schedule` function, which computes the learning rate for a given training iteration using a linear warmup followed by a cosine annealing decay.

## Key Implementations & Features
* **Linear Warmup**: Linearly ramps up the learning rate from `0` to `max_learning_rate` during the first `warmup_iters` steps.
* **Cosine Annealing**: Decays the learning rate from `max_learning_rate` to `min_learning_rate` based on a cosine curve until it reaches `cosine_cycle_iters`.
* **Post-Cycle Behavior**: Holds the learning rate constant at `min_learning_rate` for any iterations past `cosine_cycle_iters`.
* **Pythonic Control Flow**: Optimized conditional structure to eliminate redundant bounds checking and maximize readability.

## Testing
* `test_get_lr_cosine_schedule` verified and passing.
