### PR TITLE
feat: Implement Gradient Clipping by L2 Norm

### DIFF
--- a/cs336_basics/gradient_clipping.py
+++ b/cs336_basics/gradient_clipping.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+
+from collections.abc import Iterable
+
+
+def gradient_clipping(parameters: Iterable[nn.Parameter], max_l2_norm: float) -> None:
+    """
+    Clips the combined gradients of parameters to have an L2 norm of at most max_l2_norm.
+
+    The gradients of the parameters are modified in-place.
+
+    Args:
+        parameters (Iterable[nn.Parameter]): An iterable of parameters whose gradients
+            will be clipped.
+        max_l2_norm (float): The maximum allowed L2 norm of the combined gradients.
+    """
+
+    total_sq = 0
+    for param in parameters:
+        if param.grad is not None:
+            total_sq += param.grad.detach().pow(2).sum()
+
+    total_norm = torch.sqrt(total_sq)
+    if total_norm < max_l2_norm:
+        return
+
+    clip_coef = max_l2_norm / (total_norm + 1e-6)
+    for param in parameters:
+        if param.grad is not None:
+            with torch.no_grad():
+                param.grad.mul_(clip_coef)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -24,6 +24,7 @@ from cs336_basics.transformer_lm import TransformerLM
 from cs336_basics.cross_entropy import cross_entropy
 from cs336_basics.adamw import AdamW
 from cs336_basics.learning_rate_schedule import get_lr_cosine_schedule
+from cs336_basics.gradient_clipping import gradient_clipping
 
 
 def run_linear(
@@ -534,7 +535,8 @@ def run_gradient_clipping(parameters: Iterable[torch.nn.Parameter], max_l2_norm:
 
     The gradients of the parameters (parameter.grad) should be modified in-place.
     """
-    raise NotImplementedError
+
+    gradient_clipping(parameters, max_l2_norm)
 
 
 def get_adamw_cls() -> Any:


### PR DESCRIPTION
## Description
This PR implements the `gradient_clipping` function to scale parameter gradients in-place when their combined L2 norm exceeds a specified threshold.

## Key Implementations & Features
* **Combined L2 Norm**: Computes the global L2 norm of gradients aggregated across all parameters (ignoring parameters with `None` gradients).
* **Safe In-place Scaling**: Applies scaling directly to `param.grad` in-place within a `torch.no_grad()` block to avoid building computation graphs or memory leaks.
* **Numerical Stability**: Incorporates a small epsilon ($10^{-6}$) in the denominator of the clipping coefficient computation to prevent division-by-zero errors.

## Testing
* `test_gradient_clipping` verified and passing.
