### PR TITLE
feat: implement memory-efficient get_batch for data loading

### DIFF
--- a/cs336_basics/data_loading.py
+++ b/cs336_basics/data_loading.py
@@ -1,0 +1,35 @@
+import torch
+
+import numpy.typing as npt
+
+
+def get_batch(
+    dataset: npt.NDArray,
+    batch_size: int,
+    context_length: int,
+    device: torch.device | str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Given a 1D dataset of token IDs, sample a batch of input sequences and their
+    corresponding next-token target labels.
+
+    Args:
+        dataset: A 1D NumPy array containing the token IDs of the dataset.
+        batch_size: The number of sequences to sample in the batch.
+        context_length: The length of each input sequence.
+        device: The PyTorch device (e.g., 'cpu' or 'cuda') to place the tensors on.
+
+    Returns:
+        A tuple of (x, y) where x is the input sequences of shape (batch_size, context_length)
+        and y is the target sequences of shape (batch_size, context_length).
+    """
+    dataset_tensor = torch.from_numpy(dataset)
+    size = len(dataset_tensor)
+    max_index = size - context_length - 1
+    start_indices = torch.randint(0, max_index + 1, (batch_size,))
+    start_indices = start_indices[:, None]
+    offset = torch.arange(0, context_length)
+    indices = start_indices + offset
+    x = dataset_tensor[indices].to(device)
+    y = dataset_tensor[indices + 1].to(device)
+    return (x, y)

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -25,6 +25,7 @@ from cs336_basics.cross_entropy import cross_entropy
 from cs336_basics.adamw import AdamW
 from cs336_basics.learning_rate_schedule import get_lr_cosine_schedule
 from cs336_basics.gradient_clipping import gradient_clipping
+from cs336_basics.data_loading import get_batch
 
 
 def run_linear(
@@ -487,7 +488,8 @@ def run_get_batch(
         is the sampled input sequences, and the second tuple item is the corresponding
         language modeling labels.
     """
-    raise NotImplementedError
+
+    return get_batch(dataset, batch_size, context_length, device)
 
 
 def run_softmax(in_features: Float[Tensor, " ..."], dim: int) -> Float[Tensor, " ..."]:


### PR DESCRIPTION
### Summary
Implements the `get_batch` data loader function in `cs336_basics/data_loading.py` to sample language modeling input sequences and their next-token target labels from a 1D NumPy dataset.

### Detailed Changes
1. **Memory-efficient Tensor Conversion**: Utilizes `torch.from_numpy` to load the dataset, sharing CPU memory and avoiding unnecessary copy overhead.
2. **Safe Index Boundary Calculation**: Sets the maximum starting index to `dataset_size - context_length - 1` to guarantee that targets at `indices + 1` never exceed the dataset bounds.
3. **Broadcasting-based Batch Construction**: Generates input sequence indices using PyTorch broadcasting (adding a `(batch_size, 1)` tensor of starting indices with a `(context_length,)` offset tensor).
4. **Device Portability**: Transfers slice tensors to the requested `device` (`cpu`, `cuda`, etc.) after index lookup.
5. **Google-style Docstrings & Clean Naming**: Avoids shadowing Python built-ins (e.g., using `dataset_tensor` instead of `input`), conforms to PEP 8, and includes full docstring coverage.

### Verification
- Verified against the test suite by running `pytest tests/test_data.py::test_get_batch`, which passes successfully.